### PR TITLE
allow calling code to handle exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,8 @@ class Client extends \GuzzleHttp\Client
 
     private $_sCustomerId;
 
+    private $requestExceptions;
+
     public function __construct(array $config=[])
     {
         // Validate Postmates config values, these are required for the Postmates Client
@@ -184,18 +186,23 @@ class Client extends \GuzzleHttp\Client
             $oRsp = $this->send($oRq);
             return Factory::create($oRsp->json());
         } catch(\GuzzleHttp\Exception\RequestException $e) {
-            echo $e->getRequest() . "\n";
-            if($e->hasResponse()) {
-                  echo 'HTTP request URL: ' . $e->getRequest()->getUrl() . "\n";
-                  /*
-                  echo 'HTTP request: ' . $e->getRequest() . "\n";
-                  echo 'HTTP response status: ' . $e->getResponse()->getStatusCode() . "\n";
-                  echo 'HTTP response: ' . $e->getResponse() . "\n";
-                */
-                echo $e->getResponse() . "\n";
-            }
+            $this->addException($e);
         } catch(\Exception $e) {
-            echo 'Uh oh! ' . $e->getMessage();
+            $this->addException($e);
         }
+    }
+
+    private function addException($e) 
+    {
+        $this->requestExceptions[] = $e;
+    }
+
+    /**
+     * Retrieve an array of exceptions, if any were thrown during the request.
+     * See http://docs.guzzlephp.org/ for methods available with Guzzle request exceptions.
+     */
+    public function getRequestExceptions() 
+    {
+        return $this->requestExceptions;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ class TestClient extends PHPUnit_Framework_TestCase
         $_oClient,
         $_oQuote,
         $_oDelivery,
+        $_oDeliveryException,
         $_oDeliveries;
 
     protected function setUp()
@@ -29,6 +30,9 @@ class TestClient extends PHPUnit_Framework_TestCase
 
         // Create a delivery
         $this->_createDelivery();
+
+        // Generate a request exception
+        $this->_createDeliveryException();
     }
 
     // @TODO Test pagination ..
@@ -58,6 +62,18 @@ class TestClient extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('\\Postmates\\Dao\\Delivery', $this->_oDelivery);
         $this->assertInstanceOf('\\DateTime', $this->_oDelivery['dropoff_eta']);
+    }
+
+    /**
+     * Retrieve exceptions for a failed attempt to create a delivery.
+     */
+    public function testCreateDeliveryException()
+    {
+        $this->assertNull($this->_oDeliveryException);
+        $exceptions = $this->_oClient->getRequestExceptions();
+        foreach($exceptions as $e) {
+            $this->assertInstanceOf('\\GuzzleHttp\\Exception\\RequestException', $e);
+        }
     }
 
     /**
@@ -101,6 +117,24 @@ class TestClient extends PHPUnit_Framework_TestCase
             'A bag of groceries',
             'Instamart Warehouse',
             self::WAREHOUSE_ADDRESS,
+            '800-555-1234',
+            'Roy Rogers',
+            self::CUSTOMER_ADDRESS,
+            '303-425-8803',
+            '',
+            '',
+            'Instamart Online Grocery Market',
+            'Say hi to the customer for us!',
+            $this->_oQuote['id']
+        );
+    }
+
+    private function _createDeliveryException()
+    {
+        $this->_oDeliveryException = $this->_oClient->createDelivery(
+            'A bag of groceries',
+            'Instamart Warehouse',
+            'bad_address', // this will generate an exception because Postmates cannot geocode it
             '800-555-1234',
             'Roy Rogers',
             self::CUSTOMER_ADDRESS,


### PR DESCRIPTION
Hi, thanks for this library. I think it would be helpful to allow the calling code to decide what to do with exceptions when a request fails.

with these changes the calling code can do this:
$client = new \Postmates\Client(...);
if($delivery = $client->createDelivery(...) {
  //handle the delivery
}
else {
  //handle the failure
  
  $exceptions = $client->getRequestExceptions();
  foreach($exceptions as $e) {
    //do something with the exceptions: print them, log them, etc.
  }
}

useful in situations where a webhook is generating the request rather than a human with a browser.