### PR TITLE
allow guzzle version 6 to be used. Using the right variable in the test case.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "quickshiftin/postmates-client",
     "description": "Client library for Postmates On Demand Logistics",
     "require": {
-        "guzzlehttp/guzzle" : "5.2.0"
+        "guzzlehttp/guzzle" : "5.2.0|~6.0"
     },
     "license": "MIT",
     "authors": [

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -108,7 +108,7 @@ class TestClient extends PHPUnit_Framework_TestCase
         $oDelivery        = $oDeliveries[0];
         $oReverseDelivery = $this->_oClient->returnDelivery($oDelivery['id']);
 
-        $this->assertEquals($oDelivery['pickup']['address'], $oReversedDelivery['dropoff']['address']);
+        $this->assertEquals($oDelivery['pickup']['address'], $oReverseDelivery['dropoff']['address']);
     }
 
     private function _createDelivery()


### PR DESCRIPTION
Lot of my other packages use guzzle 6 and trying to install this package fails because it uses 5.2.0.

Minor variable change in the test case.